### PR TITLE
Value and Momentum Everywhere

### DIFF
--- a/Description
+++ b/Description
@@ -1,9 +1,0 @@
-"""
-This file is based on Asness, Moskowitz, Pedersen., "Value and Momentum Everywhere"., The Journal of Finance., June 2013. Original data is available at AQR's website: https://www.aqr.com/library/data-sets/value-and-momentum-everywhere-original-paper-data. 
-
-Using the excel data, I recreate the results on p.940-942, which is a table showing the mean annual return, t-stat, stdev, and sharpe ratios of US, UK, Europe, Japan, and Global stocks from 1972-2011. The authors split each geography into 3 Value portfolios, 3 Momentum portfolios, a High Value minus Low Value portfolio, High Momentum minus Low Momentum portfolio, and a 50/50 combination portfolio. This gives a total of 45 portfolios. 
-
-I am able to successfully replicate the author's results in almost all cases. In the cases where there are minor differences, I suspect this is because data for different geographies is sometimes available across different dates, and I may have treated the lack of overlaps differently. 
-
-To replicate the results, I took the mean, stdev, t-stat and sharpe of of the 3 Value and Momentum portfolios for each geography. I then calculated the spread portfolios (e.g. Value 3 - Value 1), and 50/50 portfolios and performed the same calculations. I calculate the correlations between the Value and Momentum portfolios. For Global stock portfolios, I took the average of the 4 other regions, and performed similar calculations. Finally, I summarise the results in tables.
-"""

--- a/Description
+++ b/Description
@@ -1,0 +1,9 @@
+"""
+This file is based on Asness, Moskowitz, Pedersen., "Value and Momentum Everywhere"., The Journal of Finance., June 2013. Original data is available at AQR's website: https://www.aqr.com/library/data-sets/value-and-momentum-everywhere-original-paper-data. 
+
+Using the excel data, I recreate the results on p.940-942, which is a table showing the mean annual return, t-stat, stdev, and sharpe ratios of US, UK, Europe, Japan, and Global stocks from 1972-2011. The authors split each geography into 3 Value portfolios, 3 Momentum portfolios, a High Value minus Low Value portfolio, High Momentum minus Low Momentum portfolio, and a 50/50 combination portfolio. This gives a total of 45 portfolios. 
+
+I am able to successfully replicate the author's results in almost all cases. In the cases where there are minor differences, I suspect this is because data for different geographies is sometimes available across different dates, and I may have treated the lack of overlaps differently. 
+
+To replicate the results, I took the mean, stdev, t-stat and sharpe of of the 3 Value and Momentum portfolios for each geography. I then calculated the spread portfolios (e.g. Value 3 - Value 1), and 50/50 portfolios and performed the same calculations. I calculate the correlations between the Value and Momentum portfolios. For Global stock portfolios, I took the average of the 4 other regions, and performed similar calculations. Finally, I summarise the results in tables.
+"""

--- a/Portfolio Optimizer
+++ b/Portfolio Optimizer
@@ -1,0 +1,143 @@
+"""
+The following is a portfolio optimiser, which takes the user's expected returns and covariances for a set of stocks and creates a portfolio to maximise it's sharpe ratio.
+"""
+
+import numpy as np
+import pandas as pd
+from pandas import Series, DataFrame
+import pandas.io.data as web
+import matplotlib.pyplot as plt
+import scipy.optimize as sco
+import scipy.interpolate as sci
+import datetime
+
+%matplotlib inline 
+
+data = pd.read_csv('/Users/christopherwaller/Library/Mobile Documents/com~apple~CloudDocs/Last copy of Samsung Laptop files/Documents/Documents/Investment/Data/Expected returns.csv')
+
+symbols = data.Ticker
+
+noa = len(symbols)
+
+
+# Historic Data
+
+historic_prices = DataFrame()
+
+#gives pricing data since Jan-2010.
+for sym in symbols:
+    historic_prices[sym] = web.DataReader(sym, data_source='yahoo',
+                              end=datetime.datetime.now())['Adj Close']
+    
+historic_daily_returns = np.log(historic_prices/historic_prices.shift(1))
+
+stdev_col = ['stdevs']
+stdevs = DataFrame(historic_daily_returns.std(), columns=stdev_col)
+covariances = historic_daily_returns.cov() * 252
+correlations = np.round(DataFrame(historic_daily_returns.corr()), 2)
+
+
+# Modifying Correlations/Covariances
+
+exp_cov = covariances
+exp_corr = correlations
+
+# Historic correlation probably too low
+a = 'OIL'
+b = 'PFC.L'
+c = 0.5
+exp_corr[a][b] = exp_corr[b][a] = c
+exp_cov[a][b] = exp_cov[b][a] = exp_corr[a][b] * stdevs.T[a] * stdevs.T[b] * 252
+
+# Historic correlation probably too low
+a = 'OIL'
+b = 'LEK.L'
+c = 0.3
+exp_corr[a][b] = exp_corr[b][a] = c
+exp_cov[a][b] = exp_cov[b][a] = exp_corr[a][b] * stdevs.T[a] * stdevs.T[b] * 252
+
+# Historic correlation probably too low
+a = '^FTSE'
+b = 'JD.L'
+c = 0.4
+exp_corr[a][b] = exp_corr[b][a] = c
+exp_cov[a][b] = exp_cov[b][a] = exp_corr[a][b] * stdevs.T[a] * stdevs.T[b] * 252
+
+
+# Optimizer
+
+exp_ret = data.Exp.convert_objects(convert_numeric=True)
+exp_ret_col = ['Expected Returns']
+DataFrame(zip(exp_ret), index=symbols, columns=exp_ret_col)
+
+#using current weights to begin process
+current_weights = data.Current_weight
+weights = current_weights
+weights /= np.sum(weights)
+
+port_ret = np.nansum(weights * np.array(exp_ret))
+
+exp_port_var = np.dot(weights.T, np.dot(exp_cov, weights))
+exp_port_std = np.sqrt(exp_port_var)
+
+#Monte Carlo Simulation:
+prets = []
+pvols = []
+
+for p in range(5000):
+    weights = np.random.random(noa)
+    weights /= np.sum(weights)
+    prets.append(np.sum(exp_ret * weights))
+    pvols.append(np.sqrt(np.dot(weights.T, np.dot(exp_cov, weights))))
+    
+prets = np.array(prets)
+pvols = np.array(pvols)
+
+plt.figure(figsize=(8, 4))
+plt.scatter(pvols, prets, c=prets/pvols, marker='o')
+plt.grid(True)
+plt.xlabel('expected stdev')
+plt.ylabel('expected return')
+plt.colorbar(label='Sharpe ratio')
+
+def statistics(weights):
+    weights = np.array(weights)
+    pret = np.sum(exp_ret * weights)
+    pvol = np.sqrt(np.dot(weights.T, np.dot(exp_cov, weights)))
+    return np.array([pret, pvol, pret/pvol])
+
+def min_func_sharpe(weights):
+    return -statistics(weights)[2]
+    
+#all weights equal to 1:
+cons = ({'type': 'eq', 'fun': lambda x: np.sum(x) -1})
+
+#weighted bounded between 0 and 1:
+bnds = tuple((0, 1) for x in range(noa))
+
+#inputting initial equal weights to begin optimization function:
+noa * [1./noa,]
+
+opts = sco.minimize(min_func_sharpe, noa * [1./noa,], method='SLSQP',
+                   bounds=bnds, constraints=cons)
+                
+  #optimal portfolio weights
+opt_port_weights = opts['x'].round(3)
+trades = opt_port_weights - current_weights
+
+def min_func_variance(weights):
+    return statistics(weights)[1] ** 2
+
+optv = sco.minimize(min_func_variance, noa * [1./noa,],
+                   method='SLSQP', bounds=bnds, 
+                   constraints=cons)
+
+optv['x'].round(len(symbols))
+
+
+# Results
+
+df1_cols = ['optimal weights', 'current weights', 'trades']
+df1 = DataFrame(zip(opt_port_weights, current_weights, trades), columns=df1_cols, index=symbols)
+df1
+

--- a/Value and Momentum Everywhere
+++ b/Value and Momentum Everywhere
@@ -1,0 +1,261 @@
+import pandas as pd
+from pandas import Series, DataFrame
+import numpy as np
+import math
+
+
+# General Definitions
+
+data = pd.read_csv('/Users/christopherwaller/Library/Mobile Documents/com~apple~CloudDocs/Last copy of Samsung Laptop files/Documents/Documents/Investment/Data/Value and Momentum (csv).csv')
+
+portfolios = data.columns
+n = len(data.DATE_YEAR.unique()) - 1
+
+def mean(x):
+    return x.mean() * 12
+
+def stdev(x):
+    return x.std()*math.sqrt(12)
+
+def t_stat(x, n):
+    return (mean(x) - 0)/(stdev(x)/math.sqrt(n))
+
+def sharpe(x):
+    return mean(x)/stdev(x)
+    
+means = mean(data)
+stdevs = stdev(data)
+t_stats = t_stat(data, n)
+sharpes = sharpe(data)
+
+Stock_portfolios = {
+    'mean': list(means),
+    'Stdev': list(stdevs),
+    't-stat': list(t_stats),
+    'Sharpe': list(sharpes)
+}
+
+
+
+# US stocks
+
+#creating DataFrame for Value and Momentum portfolios P1, P2, P3
+df1 = DataFrame(Stock_portfolios, index=portfolios).drop(['DATE_YEAR'], axis=0).T
+df1 = df1.T.ix[0:6].T
+# **the ix varies depending on country/asset class etc 
+
+#creating DataFrame for Value and Momentum arbitrage portfolios P3-P1
+# **change US to relevant geography/asset class
+VAL3_1 = data.VAL3US - data.VAL1US
+MOM3_1 = data.MOM3US - data.MOM1US
+VAL_MOM = VAL3_1 * 0.5 + MOM3_1 * 0.5
+
+spreads = [VAL3_1, MOM3_1, VAL_MOM]
+
+spread_means = []
+spread_stds = []
+spread_ts = []
+spread_sharpes = []
+
+for list in spreads:
+    spread_means.append(mean(list))
+    spread_stds.append(stdev(list))
+    spread_ts.append(t_stat(list, n))
+    spread_sharpes.append(sharpe(list))
+    
+Arbitrage_portfolios = {
+    'mean': spread_means,
+    'Stdev': spread_stds,
+    't-stat': spread_ts,
+    'Sharpe': spread_sharpes
+}
+
+portfolios2 = ['VAL3_1', 'MOM3_1', 'VAL_MOM']
+
+df2 = DataFrame(Arbitrage_portfolios, index=portfolios2).T
+
+#bringing df1 and df2 together for DataFrame with all portfolios
+frames = [df1.T.ix[:6], df2.T]
+# the ix varies depending on country/asset class etc
+
+df3 = pd.concat(frames)
+cols = df3.columns.tolist()
+cols = cols[2:] + cols[1:2] + cols[0:1]
+df3 = df3[cols].T
+np.round(df3, 3)
+
+VAL_MOM_CORR = VAL3_1.corr(MOM3_1)
+print "Correlation (Val, Mom) =", round(VAL_MOM_CORR, 2)
+
+
+
+# UK stocks
+
+n = len(data.VAL1UK.value_counts(dropna=True))/12
+n2 = len(data.MOM1UK.value_counts(dropna=True))/12
+
+#creating DataFrame for Value and Momentum portfolios P1, P2, P3
+df1 = DataFrame(Stock_portfolios, index=portfolios).drop(['DATE_YEAR'], axis=0).T
+df1 = df1.T.ix[6:12].T
+# **the ix varies depending on country/asset class etc 
+
+#creating DataFrame for Value and Momentum portfolios P3-P1
+# **change US to relevant heading
+VAL3_1 = data.VAL3UK - data.VAL1UK
+MOM3_1 = data.MOM3UK - data.MOM1UK
+VAL_MOM = VAL3_1 * 0.5 + MOM3_1 * 0.5
+
+Arbitrage_portfolios = {
+    'mean': [mean(VAL3_1), mean(MOM3_1), mean(VAL_MOM)],
+    'Stdev': [stdev(VAL3_1), stdev(MOM3_1), stdev(VAL_MOM)],
+    't-stat': [t_stat(VAL3_1, n), t_stat(MOM3_1, n2), t_stat(VAL_MOM, n)],
+    'Sharpe': [sharpe(VAL3_1), sharpe(MOM3_1), sharpe(VAL_MOM)]
+}
+
+portfolios2 = ['VAL3_1', 'MOM3_1', 'VAL_MOM']
+
+df2 = DataFrame(Arbitrage_portfolios, index=portfolios2).T
+
+#bringing df1 and df2 together for DataFrame with all portfolios
+frames = [df1.T, df2.T]
+
+df3 = pd.concat(frames)
+cols = df3.columns.tolist()
+cols = cols[2:] + cols[1:2] + cols[0:1]
+df3 = df3[cols].T
+np.round(df3, 3)
+
+VAL_MOM_CORR = VAL3_1.corr(MOM3_1)
+print "Correlation (Val, Mom) =", round(VAL_MOM_CORR, 2)
+
+
+
+# Europe stocks
+
+n = len(data.VAL1EU.value_counts(dropna=True))/12
+n2 = len(data.MOM1EU.value_counts(dropna=True))/12
+
+#creating DataFrame for Value and Momentum portfolios P1, P2, P3
+df1 = DataFrame(Stock_portfolios, index=portfolios).drop(['DATE_YEAR'], axis=0).T
+df1 = df1.T.ix[12:18].T
+# **the ix varies depending on country/asset class etc 
+
+#creating DataFrame for Value and Momentum portfolios P3-P1
+# **change US to relevant heading
+VAL3_1 = data.VAL3EU - data.VAL1EU
+MOM3_1 = data.MOM3EU - data.MOM1EU
+VAL_MOM = VAL3_1 * 0.5 + MOM3_1 * 0.5
+
+Arbitrage_portfolios = {
+    'mean': [mean(VAL3_1), mean(MOM3_1), mean(VAL_MOM)],
+    'Stdev': [stdev(VAL3_1), stdev(MOM3_1), stdev(VAL_MOM)],
+    't-stat': [t_stat(VAL3_1, n), t_stat(MOM3_1, n2), t_stat(VAL_MOM, n)],
+    'Sharpe': [sharpe(VAL3_1), sharpe(MOM3_1), sharpe(VAL_MOM)]
+}
+
+portfolios2 = ['VAL3_1', 'MOM3_1', 'VAL_MOM']
+
+df2 = DataFrame(Arbitrage_portfolios, index=portfolios2).T
+
+#bringing df1 and df2 together for DataFrame with all portfolios
+frames = [df1.T, df2.T]
+
+df3 = pd.concat(frames)
+cols = df3.columns.tolist()
+cols = cols[2:] + cols[1:2] + cols[0:1]
+df3 = df3[cols].T
+np.round(df3, 3)
+
+VAL_MOM_CORR = VAL3_1.corr(MOM3_1)
+print "Correlation (Val, Mom) =", round(VAL_MOM_CORR, 2)
+
+
+
+# Japan stocks
+
+n = len(data.VAL1JP.value_counts(dropna=True))/12
+n2 = len(data.MOM1JP.value_counts(dropna=True))/12
+
+#creating DataFrame for Value and Momentum portfolios P1, P2, P3
+df1 = DataFrame(Stock_portfolios, index=portfolios).drop(['DATE_YEAR'], axis=0).T
+df1 = df1.T.ix[18:24].T
+# **the ix varies depending on country/asset class etc 
+
+#creating DataFrame for Value and Momentum portfolios P3-P1
+# **change US to relevant heading
+VAL3_1 = data.VAL3JP - data.VAL1JP
+MOM3_1 = data.MOM3JP - data.MOM1JP
+VAL_MOM = VAL3_1 * 0.5 + MOM3_1 * 0.5
+
+Arbitrage_portfolios = {
+    'mean': [mean(VAL3_1), mean(MOM3_1), mean(VAL_MOM)],
+    'Stdev': [stdev(VAL3_1), stdev(MOM3_1), stdev(VAL_MOM)],
+    't-stat': [t_stat(VAL3_1, n), t_stat(MOM3_1, n2), t_stat(VAL_MOM, n)],
+    'Sharpe': [sharpe(VAL3_1), sharpe(MOM3_1), sharpe(VAL_MOM)]
+}
+
+portfolios2 = ['VAL3_1', 'MOM3_1', 'VAL_MOM']
+
+df2 = DataFrame(Arbitrage_portfolios, index=portfolios2).T
+
+#bringing df1 and df2 together for DataFrame with all portfolios
+frames = [df1.T, df2.T]
+
+df3 = pd.concat(frames)
+cols = df3.columns.tolist()
+cols = cols[2:] + cols[1:2] + cols[0:1]
+df3 = df3[cols].T
+np.round(df3, 3)
+
+VAL_MOM_CORR = VAL3_1.corr(MOM3_1)
+print "Correlation (Val, Mom) =", round(VAL_MOM_CORR, 2)
+
+
+
+# Global stocks
+
+#creating global portfolios as no data in excel
+VAL1GL = sum([data.VAL1US, data.VAL1UK, data.VAL1EU, data.VAL1JP]) / 4
+VAL2GL = sum([data.VAL2US, data.VAL2UK, data.VAL2EU, data.VAL2JP]) / 4
+VAL3GL = sum([data.VAL3US, data.VAL3UK, data.VAL3EU, data.VAL3JP]) / 4
+MOM1GL = sum([data.MOM1US, data.MOM1UK, data.MOM1EU, data.MOM1JP]) / 4
+MOM2GL = sum([data.MOM2US, data.MOM2UK, data.MOM2EU, data.MOM2JP]) / 4
+MOM3GL = sum([data.MOM3US, data.MOM3UK, data.MOM3EU, data.MOM3JP]) / 4
+VAL3_1 = VAL3GL - VAL1GL
+MOM3_1 = MOM3GL - MOM1GL
+VAL_MOM = VAL3_1 * 0.5 + MOM3_1 * 0.5
+
+portfolios = [VAL1GL, VAL2GL, VAL3GL, MOM1GL, MOM2GL, MOM3GL,
+             VAL3_1, MOM3_1, VAL_MOM]
+
+n = len(VAL1GL.value_counts(dropna=False))/12
+
+means = []
+stds = []
+ts = []
+sharpes = []
+
+for list in portfolios:
+    means.append(mean(list))
+    stds.append(stdev(list))
+    ts.append(t_stat(list, n))
+    sharpes.append(sharpe(list))
+    
+Stock_portfolios = {
+    'mean': means,
+    'Stdev': stds,
+    't-stat': ts,
+    'Sharpe': sharpes
+}
+
+portfolios = ['VAL1GL', 'VAL2GL', 'VAL3GL', 'MOM1GL', 'MOM2GL', 'MOM3GL',
+             'VAL3_1', 'MOM3_1', 'VAL_MOM']
+
+df1 = DataFrame(Stock_portfolios, index=portfolios)
+cols = df1.columns.tolist()
+cols = cols[2:] + cols[1:2] + cols[0:1]
+df1 = df1[cols]
+np.round(df1.T, 3)
+
+VAL_MOM_CORR = VAL3_1.corr(MOM3_1)
+print "Correlation (Val, Mom) =", round(VAL_MOM_CORR, 2)

--- a/Value and Momentum Everywhere
+++ b/Value and Momentum Everywhere
@@ -1,3 +1,24 @@
+#This file is based on Asness, Moskowitz, Pedersen., "Value and Momentum Everywhere"., The Journal of Finance., June 2013.
+#(http://pages.stern.nyu.edu/~lpederse/papers/ValMomEverywhere.pdf). Original data is available at AQR's website: 
+#https://www.aqr.com/library/data-sets/value-and-momentum-everywhere-original-paper-data.
+#
+#Using the excel data, I recreate the results on p.940-942, which is a table showing the mean annual return, t-stat, stdev,
+#and sharpe ratios of US, UK, Europe, Japan, and Global stocks from 1972-2011. The authors split each geography into 3
+#Value portfolios, 3 Momentum portfolios, a High Value minus Low Value portfolio, High Momentum minus Low Momentum
+#portfolio, and a 50/50 combination portfolio. This gives a total of 45 portfolios.
+#
+#I am able to successfully replicate the author's results in almost all cases. In the cases where there are minor 
+#differences, I suspect this is because data for different geographies is sometimes available across different dates, 
+#and I may have treated the lack of overlaps differently.
+#
+#To replicate the results, I took the mean, stdev, t-stat and sharpe of of the 3 Value and Momentum portfolios for 
+#each geography. I then calculated the spread portfolios (e.g. Value 3 - Value 1), and 50/50 portfolios and performed 
+#the same calculations. I calculate the correlations between the Value and Momentum portfolios. For Global stock 
+#portfolios, I took the average of the 4 other regions, and performed similar calculations. Finally, I summarise 
+#the results in tables.
+
+
+
 import pandas as pd
 from pandas import Series, DataFrame
 import numpy as np


### PR DESCRIPTION
This file is based on Asness, Moskowitz, Pedersen., "Value and Momentum Everywhere"., The Journal of Finance., June 2013. (http://pages.stern.nyu.edu/~lpederse/papers/ValMomEverywhere.pdf). Original data is available at AQR's website: https://www.aqr.com/library/data-sets/value-and-momentum-everywhere-original-paper-data. 

Using the excel data, I recreate the results on p.940-942, which is a table showing the mean annual return, t-stat, stdev, and sharpe ratios of US, UK, Europe, Japan, and Global stocks from 1972-2011. The authors split each geography into 3 Value portfolios, 3 Momentum portfolios, a High Value minus Low Value portfolio, High Momentum minus Low Momentum portfolio, and a 50/50 combination portfolio. This gives a total of 45 portfolios. 

I am able to successfully replicate the author's results in almost all cases. In the cases where there are minor differences, I suspect this is because data for different geographies is sometimes available across different dates, and I may have treated the lack of overlaps differently. 

To replicate the results, I took the mean, stdev, t-stat and sharpe of of the 3 Value and Momentum portfolios for each geography. I then calculated the spread portfolios (e.g. Value 3 - Value 1), and 50/50 portfolios and performed the same calculations. I calculate the correlations between the Value and Momentum portfolios. For Global stock portfolios, I took the average of the 4 other regions, and performed similar calculations. Finally, I summarise the results in tables.
